### PR TITLE
fix: handle version -N suffixes in release check widgets

### DIFF
--- a/js/widgets.js
+++ b/js/widgets.js
@@ -346,12 +346,16 @@ const WIDGETS = {
           
           const cur = (data.current || '').replace(/^v/, '');
           const lat = (data.latest || '').replace(/^v/, '');
+          // Strip -N suffixes for comparison (e.g. 2026.2.22-2 matches 2026.2.22)
+          const curBase = cur.replace(/-\d+$/, '');
+          const latBase = lat.replace(/-\d+$/, '');
+          const isUpToDate = cur === lat || curBase === latBase || cur.startsWith(latBase + '-');
           
           if (!cur || cur === 'unknown') {
             currentEl.textContent = 'v' + lat;
             statusEl.textContent = 'Latest release';
             statusEl.style.color = '#8b949e';
-          } else if (cur === lat) {
+          } else if (isUpToDate) {
             currentEl.textContent = 'v' + cur;
             currentEl.style.color = '#3fb950';
             statusEl.innerHTML = '✓ Up to date';
@@ -424,12 +428,16 @@ const WIDGETS = {
           
           const cur = (data.current || '').replace(/^v/, '');
           const lat = (data.latest || '').replace(/^v/, '');
+          // Strip -N suffixes for comparison (e.g. 2026.2.22-2 matches 2026.2.22)
+          const curBase = cur.replace(/-\d+$/, '');
+          const latBase = lat.replace(/-\d+$/, '');
+          const isUpToDate = cur === lat || curBase === latBase || cur.startsWith(latBase + '-');
           
           if (!cur || cur === 'unknown') {
             currentEl.textContent = 'v' + lat;
             statusEl.textContent = 'Latest release';
             statusEl.style.color = '#8b949e';
-          } else if (cur === lat) {
+          } else if (isUpToDate) {
             currentEl.textContent = 'v' + cur;
             currentEl.style.color = '#3fb950';
             statusEl.innerHTML = '✓ Up to date';


### PR DESCRIPTION
## Problem

The LobsterBoard and OpenClaw release check widgets use strict string equality (`cur === lat`) to compare versions. When the installed version has a `-N` suffix (e.g. `2026.2.22-2` from npm), it doesn't match the GitHub release tag (`v2026.2.22`), causing a permanent false **"Update available"** indicator.

## Fix

Strip `-N` suffixes before comparing, so `2026.2.22-2` correctly matches `2026.2.22` as up to date. Applied to both the `lb-release` and `openclaw-release` widgets.

Fixes #5