### PR TITLE
fix: show actual error message when template import fails

### DIFF
--- a/js/templates.js
+++ b/js/templates.js
@@ -155,7 +155,7 @@
         tplGrid.style.display = '';
         loadTemplates();
       } else {
-        alert('❌ ' + (data.error || 'Delete failed'));
+        alert('❌ ' + (data.error || data.message || 'Delete failed'));
       }
     } catch (e) {
       alert('❌ Delete failed: ' + e.message);
@@ -187,7 +187,7 @@
         alert(`✅ ${data.message}\n\nReloading dashboard...`);
         location.reload();
       } else {
-        alert('❌ ' + (data.error || 'Import failed'));
+        alert('❌ ' + (data.error || data.message || 'Import failed'));
       }
     } catch (e) {
       alert('❌ Import failed: ' + e.message);

--- a/server.cjs
+++ b/server.cjs
@@ -1458,12 +1458,25 @@ const server = http.createServer(async (req, res) => {
     req.on('end', () => {
       try {
         const { id, mode } = JSON.parse(body);
+        if (!id) { sendJson(res, 400, { error: 'Missing template id' }); return; }
+        if (!mode) { sendJson(res, 400, { error: 'Missing import mode' }); return; }
+        
         const tplConfigPath = path.join(TEMPLATES_DIR, id, 'config.json');
-        if (!fs.existsSync(tplConfigPath)) { sendJson(res, 404, { error: 'Template not found' }); return; }
-        const tplConfig = JSON.parse(fs.readFileSync(tplConfigPath, 'utf8'));
+        if (!fs.existsSync(tplConfigPath)) { sendJson(res, 404, { error: `Template "${id}" not found` }); return; }
+        
+        let tplConfig;
+        try {
+          tplConfig = JSON.parse(fs.readFileSync(tplConfigPath, 'utf8'));
+        } catch (parseErr) {
+          sendJson(res, 500, { error: `Template config is invalid JSON: ${parseErr.message}` }); return;
+        }
 
         if (mode === 'replace') {
-          fs.writeFileSync(CONFIG_FILE, JSON.stringify(tplConfig, null, 2));
+          try {
+            fs.writeFileSync(CONFIG_FILE, JSON.stringify(tplConfig, null, 2));
+          } catch (writeErr) {
+            sendJson(res, 500, { error: `Failed to write config: ${writeErr.message}` }); return;
+          }
           sendJson(res, 200, { status: 'success', message: 'Template imported (replace)' });
         } else if (mode === 'merge') {
           let currentConfig = { canvas: { width: 1920, height: 1080 }, widgets: [] };
@@ -1481,12 +1494,16 @@ const server = http.createServer(async (req, res) => {
             y: (w.y || 0) + offset
           }));
           currentConfig.widgets = [...(currentConfig.widgets || []), ...newWidgets];
-          fs.writeFileSync(CONFIG_FILE, JSON.stringify(currentConfig, null, 2));
+          try {
+            fs.writeFileSync(CONFIG_FILE, JSON.stringify(currentConfig, null, 2));
+          } catch (writeErr) {
+            sendJson(res, 500, { error: `Failed to write config: ${writeErr.message}` }); return;
+          }
           sendJson(res, 200, { status: 'success', message: `Merged ${newWidgets.length} widgets` });
         } else {
           sendJson(res, 400, { error: 'Invalid mode. Use "replace" or "merge"' });
         }
-      } catch (e) { sendError(res, e.message); }
+      } catch (e) { sendJson(res, 500, { error: `Import error: ${e.message}` }); }
     });
     return;
   }


### PR DESCRIPTION
## Problem

When template import fails, users only see a generic "Import failed" message with no details about what went wrong (#9).

**Root cause:** The server returns errors as `{ status: 'error', message: '...' }` but the client checks `data.error` — which is always undefined, so it falls back to the generic message.

## Changes

### Client (js/templates.js)
- Check both `data.error` and `data.message` response fields

### Server (server.cjs)
- Return consistent `{ error: '...' }` format (not `{ message: '...' }`)
- Added validation for missing `id` and `mode` params
- Separate try/catch blocks for JSON parsing vs file writing
- Specific error messages:
  - `Template "xyz" not found`
  - `Template config is invalid JSON: ...`
  - `Failed to write config: EACCES permission denied`

## Testing

1. Try importing a template — should work, or show a useful error
2. Try with public mode enabled — should show "Dashboard is in public mode. Editing is disabled."
3. Try with read-only config.json — should show permission error

Fixes #9