### PR TITLE
Expand Gemini CLI quota bucket detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Track your AI coding subscriptions in real-time. Inspired by [OpenUsage](https:/
 | Codex CLI | Session, weekly, code reviews | Run `codex` once |
 | GitHub Copilot | Premium, chat, completions | Run `gh auth login` |
 | Cursor | Credits, usage breakdown | Just use Cursor IDE |
-| Gemini CLI | Pro, flash models | Run `gemini` once |
+| Gemini CLI | All available Gemini CLI quota buckets | Run `gemini` once |
 | Amp | Free tier, credits | Run `amp` once |
 | Factory / Droid | Standard, premium tokens | Run `factory` once |
 | Kimi Code | Session, weekly | Run `kimi` once |

--- a/server.cjs
+++ b/server.cjs
@@ -1289,16 +1289,16 @@ async function fetchGeminiUsage() {
     // Parse quota buckets (API returns 'buckets' with 'remainingFraction')
     const buckets = data.buckets || data.quotaBuckets || [];
     
-    // Filter for interesting models and REQUESTS type
-    const interestingModels = ['gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-2.0-flash'];
+    // Track all non-Vertex Gemini request buckets instead of a hardcoded
+    // 2.x allowlist so new Gemini CLI quota windows surface automatically.
     const seen = new Set();
     
     for (const bucket of buckets) {
       if (bucket.tokenType !== 'REQUESTS') continue;
       // Skip vertex variants
       if (bucket.modelId?.includes('_vertex')) continue;
-      // Only show interesting models
-      if (!interestingModels.some(m => bucket.modelId?.startsWith(m))) continue;
+      // Only show Gemini model buckets
+      if (!bucket.modelId?.startsWith('gemini-')) continue;
       // Dedupe
       if (seen.has(bucket.modelId)) continue;
       seen.add(bucket.modelId);
@@ -1313,6 +1313,8 @@ async function fetchGeminiUsage() {
       });
     }
     
+    metrics.sort((a, b) => String(a.label || '').localeCompare(String(b.label || '')));
+
     return {
       ...baseInfo,
       plan: 'Gemini CLI',


### PR DESCRIPTION
## Summary
- expand Gemini CLI quota detection to include all non-Vertex Gemini request buckets instead of a hardcoded 2.x allowlist
- surface newly available Gemini CLI quota windows automatically when Google adds them
- update the README description for the Gemini CLI collector

## Why
The current Gemini CLI collector only includes a hardcoded set of 2.x models. On a live Gemini CLI account, the `retrieveUserQuota` endpoint is already returning an additional Gemini 3-family bucket:
- `gemini-3.1-flash-lite-preview`

Because LobsterBoard filters to a fixed allowlist, that quota window is silently dropped today.

This change keeps the existing safeguards:
- only `REQUESTS` buckets
- skip `_vertex` variants
- dedupe by `modelId`

while allowing new Gemini CLI quota buckets to show up automatically.

## Validation
- verified live `retrieveUserQuota` response includes:
  - `gemini-2.5-flash`
  - `gemini-2.5-flash-lite`
  - `gemini-2.5-pro`
  - `gemini-3.1-flash-lite-preview`
- verified the new selection logic includes all of the above
