### PR TITLE
fix: parse openclaw --version output for accurate release comparison

### DIFF
--- a/server.cjs
+++ b/server.cjs
@@ -2755,7 +2755,10 @@ const server = http.createServer(async (req, res) => {
         try {
           // Run openclaw --version to get the actual running version
           const { execSync } = require('child_process');
-          currentVersion = execSync('openclaw --version 2>/dev/null', { encoding: 'utf8', timeout: 5000 }).trim();
+          const cliOutput = execSync('openclaw --version 2>/dev/null', { encoding: 'utf8', timeout: 5000 }).trim();
+          // Output format: "OpenClaw 2026.3.23-2 (hash)" — extract just the version
+          const vMatch = cliOutput.match(/(\d{4}\.\d+\.\d+(?:-\d+)?)/);
+          currentVersion = vMatch ? vMatch[1] : cliOutput;
         } catch (_) {
           // Fallback: try reading from package.json
           try {


### PR DESCRIPTION
## Problem

The OpenClaw release widget shows "Update available" even when the installed version matches the latest GitHub release.

The `openclaw --version` CLI outputs a formatted string like:
```
OpenClaw 2026.3.23-2 (7ffe7e4)
```

But the widget compared this full string against the GitHub tag `v2026.3.23`, which never matched.

## Fix

Extract just the semver-like version number (`2026.3.23-2`) from the CLI output using a regex, so the existing base-version comparison logic (which already handles `v` prefixes and `-N` suffixes) works correctly.

## Testing

Before: `/api/releases` returns `{"current": "OpenClaw 2026.3.23-2 (7ffe7e4)", ...}` → widget shows "Update available"
After: `/api/releases` returns `{"current": "2026.3.23-2", ...}` → widget shows "✓ Up to date"