### PR TITLE
feat: stock-ticker, crypto-price, and search widgets

### DIFF
--- a/app.html
+++ b/app.html
@@ -761,6 +761,8 @@
   <script src="js/widgets/layout.js"></script>
   <script src="js/widgets/releases.js"></script>
   <script src="js/widgets/misc.js"></script>
+  <script src="js/widgets/search.js"></script>
+  <script src="js/widgets/finance.js"></script>
   <!-- Editor modules (order matters: state first, index last) -->
   <script src="js/editor/state.js"></script>
   <script src="js/editor/canvas.js"></script>

--- a/js/widgets.js
+++ b/js/widgets.js
@@ -4108,6 +4108,208 @@ const WIDGETS = {
     `
   },
 
+  // ── Finance ──────────────────────────────────────────────────────────────
+
+  'stock-ticker': {
+    name: 'Stock Ticker',
+    icon: '📈',
+    category: 'large',
+    description: 'Live stock prices via Yahoo Finance. No API key required.',
+    defaultWidth: 320,
+    defaultHeight: 280,
+    hasApiKey: false,
+    properties: {
+      title: 'Stocks',
+      symbols: 'AAPL,MSFT,GOOGL,AMZN',
+      refreshInterval: 300
+    },
+    preview: `<div style="padding:6px;font-size:11px;">
+      <div style="display:flex;justify-content:space-between;"><span>AAPL</span><span>$182.50 <span style="color:#3fb950;">+1.24%</span></span></div>
+      <div style="display:flex;justify-content:space-between;"><span>MSFT</span><span>$375.20 <span style="color:#f85149;">-0.38%</span></span></div>
+    </div>`,
+    generateHtml: (props) => `
+      <div class="dash-card" id="widget-${props.id}" style="height:100%;">
+        <div class="dash-card-head">
+          <span class="dash-card-title">${renderIcon('stock')} ${props.title || 'Stocks'}</span>
+          <span class="dash-card-badge" id="${props.id}-badge">—</span>
+        </div>
+        <div class="dash-card-body" id="${props.id}-list" style="overflow-y:auto;padding:4px 8px;">
+          <div style="color:#8b949e;font-size:12px;">Loading...</div>
+        </div>
+      </div>`,
+    generateJs: (props) => `
+      async function update_${props.id.replace(/-/g, '_')}() {
+        var list = document.getElementById('${props.id}-list');
+        var badge = document.getElementById('${props.id}-badge');
+        if (!list) return;
+        try {
+          var res = await fetch('/api/finance/stocks?symbols=' + encodeURIComponent('${props.symbols || 'AAPL,MSFT'}'));
+          if (!res.ok) throw new Error('HTTP ' + res.status);
+          var data = await res.json();
+          var ok = data.filter(function(d) { return !d.error; });
+          list.innerHTML = data.map(function(d) {
+            if (d.error) return '<div style="padding:5px 0;border-bottom:1px solid #21262d;color:#8b949e;font-size:12px;">' + _esc(d.symbol) + ' — ' + _esc(d.error) + '</div>';
+            var color = d.up ? '#3fb950' : '#f85149';
+            return '<div style="display:flex;justify-content:space-between;align-items:center;padding:5px 0;border-bottom:1px solid #21262d;">'
+              + '<span style="font-weight:600;font-size:13px;">' + _esc(d.symbol) + '</span>'
+              + '<span style="text-align:right;">'
+              + '<span style="font-size:13px;font-weight:700;margin-right:8px;">$' + _esc(d.price) + '</span>'
+              + '<span style="font-size:11px;color:' + color + ';font-weight:600;">' + _esc(d.pctChange) + '%</span>'
+              + '</span></div>';
+          }).join('');
+          if (badge) badge.textContent = ok.length + ' stocks';
+        } catch (e) {
+          console.error('Stock ticker error:', e);
+          if (list) list.innerHTML = '<div style="color:#f85149;font-size:12px;">Failed to load</div>';
+        }
+      }
+      update_${props.id.replace(/-/g, '_')}();
+      setInterval(update_${props.id.replace(/-/g, '_')}, ${(props.refreshInterval || 300) * 1000});
+    `
+  },
+
+  'crypto-price': {
+    name: 'Crypto Price',
+    icon: '₿',
+    category: 'large',
+    description: 'Live crypto prices via CoinGecko. No API key required.',
+    defaultWidth: 320,
+    defaultHeight: 280,
+    hasApiKey: false,
+    properties: {
+      title: 'Crypto',
+      coins: 'bitcoin,ethereum,solana',
+      currency: 'usd',
+      refreshInterval: 300
+    },
+    preview: `<div style="padding:6px;font-size:11px;">
+      <div style="display:flex;justify-content:space-between;"><span>Bitcoin</span><span>$67,240 <span style="color:#3fb950;">+2.1%</span></span></div>
+      <div style="display:flex;justify-content:space-between;"><span>Ethereum</span><span>$3,521 <span style="color:#f85149;">-0.8%</span></span></div>
+    </div>`,
+    generateHtml: (props) => `
+      <div class="dash-card" id="widget-${props.id}" style="height:100%;">
+        <div class="dash-card-head">
+          <span class="dash-card-title">${renderIcon('crypto')} ${props.title || 'Crypto'}</span>
+          <span class="dash-card-badge" id="${props.id}-badge">—</span>
+        </div>
+        <div class="dash-card-body" id="${props.id}-list" style="overflow-y:auto;padding:4px 8px;">
+          <div style="color:#8b949e;font-size:12px;">Loading...</div>
+        </div>
+      </div>`,
+    generateJs: (props) => `
+      async function update_${props.id.replace(/-/g, '_')}() {
+        var list = document.getElementById('${props.id}-list');
+        var badge = document.getElementById('${props.id}-badge');
+        if (!list) return;
+        try {
+          var res = await fetch('/api/finance/crypto?coins=' + encodeURIComponent('${props.coins || 'bitcoin,ethereum'}') + '&currency=${props.currency || 'usd'}');
+          if (!res.ok) throw new Error('HTTP ' + res.status);
+          var data = await res.json();
+          list.innerHTML = data.map(function(d) {
+            var color = d.up ? '#3fb950' : '#f85149';
+            return '<div style="display:flex;justify-content:space-between;align-items:center;padding:5px 0;border-bottom:1px solid #21262d;">'
+              + '<span style="font-weight:600;font-size:13px;">' + _esc(d.name) + '</span>'
+              + '<span style="text-align:right;">'
+              + '<span style="font-size:13px;font-weight:700;margin-right:8px;">${(props.currency || 'usd').toUpperCase()} ' + _esc(d.price) + '</span>'
+              + '<span style="font-size:11px;color:' + color + ';font-weight:600;">' + _esc(d.pctChange) + '%</span>'
+              + '</span></div>';
+          }).join('');
+          if (badge) badge.textContent = data.length + ' coins';
+        } catch (e) {
+          console.error('Crypto price error:', e);
+          if (list) list.innerHTML = '<div style="color:#f85149;font-size:12px;">Failed to load</div>';
+        }
+      }
+      update_${props.id.replace(/-/g, '_')}();
+      setInterval(update_${props.id.replace(/-/g, '_')}, ${(props.refreshInterval || 300) * 1000});
+    `
+  },
+
+  // ── Search ────────────────────────────────────────────────────────────────
+
+  'search': {
+    name: 'Search',
+    icon: '🔍',
+    category: 'large',
+    description: 'Search box with DuckDuckGo-style !bangs. Press S to focus, ↑ for last query.',
+    defaultWidth: 460,
+    defaultHeight: 120,
+    hasApiKey: false,
+    properties: {
+      title: 'Search',
+      placeholder: 'Search or use !bangs',
+      searchEngine: 'duckduckgo',
+      openInNewTab: true,
+      showBangHints: true
+    },
+    preview: `<div style="padding:10px;">
+      <input style="width:100%;padding:6px 10px;background:#21262d;border:1px solid #30363d;border-radius:6px;color:#e6edf3;font-size:13px;" placeholder="Search or use !bangs" readonly />
+      <div style="font-size:10px;color:#8b949e;margin-top:6px;">!yt YouTube &nbsp; !gh GitHub &nbsp; !r Reddit &nbsp; !so Stack Overflow</div>
+    </div>`,
+    generateHtml: (props) => `
+      <div class="dash-card" id="widget-${props.id}" style="height:100%;">
+        <div class="dash-card-head">
+          <span class="dash-card-title">${renderIcon('search')} ${props.title || 'Search'}</span>
+        </div>
+        <div class="dash-card-body" style="padding:8px 10px;">
+          <form id="${props.id}-form" style="display:flex;gap:6px;" onsubmit="return false;">
+            <input id="${props.id}-input" type="text"
+              placeholder="${props.placeholder || 'Search or use !bangs'}"
+              autocomplete="off" spellcheck="false"
+              style="flex:1;padding:7px 11px;background:#21262d;border:1px solid #30363d;border-radius:6px;color:#e6edf3;font-size:13px;outline:none;" />
+            <button id="${props.id}-btn" type="submit"
+              style="padding:7px 14px;background:#238636;border:none;border-radius:6px;color:#fff;font-size:13px;cursor:pointer;">Go</button>
+          </form>
+          ${props.showBangHints !== false ? `<div id="${props.id}-hints" style="font-size:10px;color:#8b949e;margin-top:5px;line-height:1.6;"><span style="opacity:.7;">!g Google &nbsp; !yt YouTube &nbsp; !gh GitHub &nbsp; !r Reddit &nbsp; !so Stack Overflow &nbsp; !w Wikipedia &nbsp; !npm npm</span></div>` : ''}
+        </div>
+      </div>`,
+    generateJs: (props) => {
+      const providers = {
+        duckduckgo: 'https://duckduckgo.com/?q={q}',
+        google:     'https://www.google.com/search?q={q}',
+        bing:       'https://www.bing.com/search?q={q}',
+        brave:      'https://search.brave.com/search?q={q}'
+      };
+      const bangs = {
+        g:'https://www.google.com/search?q={q}',b:'https://www.bing.com/search?q={q}',
+        yt:'https://www.youtube.com/results?search_query={q}',gh:'https://github.com/search?q={q}',
+        r:'https://www.reddit.com/search/?q={q}',so:'https://stackoverflow.com/search?q={q}',
+        w:'https://en.wikipedia.org/wiki/Special:Search/{q}',img:'https://www.google.com/search?tbm=isch&q={q}',
+        maps:'https://www.google.com/maps/search/{q}',ddg:'https://duckduckgo.com/?q={q}',
+        npm:'https://www.npmjs.com/search?q={q}',mdn:'https://developer.mozilla.org/en-US/search?q={q}',
+        x:'https://x.com/search?q={q}',tw:'https://x.com/search?q={q}'
+      };
+      const defaultUrl = providers[props.searchEngine] || providers.duckduckgo;
+      const newTab = props.openInNewTab !== false;
+      return `
+        (function() {
+          var BANGS = ${JSON.stringify(bangs)};
+          var DEFAULT_URL = '${defaultUrl}';
+          var lastQuery = '';
+          function navigate(q) {
+            q = q.trim(); if (!q) return; lastQuery = q;
+            var url = DEFAULT_URL;
+            var m = q.match(/^!(\\S+)\\s*(.*)/);
+            if (m) { var bang = m[1].toLowerCase(), rest = m[2]; if (BANGS[bang]) { url = BANGS[bang]; q = rest || q; } }
+            var target = url.replace('{q}', encodeURIComponent(q));
+            if (${newTab}) { window.open(target, '_blank', 'noopener'); } else { window.location.href = target; }
+          }
+          var form = document.getElementById('${props.id}-form');
+          var input = document.getElementById('${props.id}-input');
+          if (form) form.addEventListener('submit', function() { navigate(input.value); });
+          if (input) input.addEventListener('keydown', function(e) { if (e.key === 'ArrowUp') { e.preventDefault(); input.value = lastQuery; } });
+          document.addEventListener('keydown', function(e) {
+            var tag = document.activeElement && document.activeElement.tagName;
+            if (e.key === 's' && tag !== 'INPUT' && tag !== 'TEXTAREA' && !e.ctrlKey && !e.metaKey) {
+              var inp = document.getElementById('${props.id}-input');
+              if (inp) { inp.focus(); inp.select(); e.preventDefault(); }
+            }
+          });
+        })();
+      `;
+    }
+  },
+
 };
 
 // Export for use in builder

--- a/js/widgets/finance.js
+++ b/js/widgets/finance.js
@@ -1,0 +1,146 @@
+/**
+ * LobsterBoard Finance Widgets
+ * stock-ticker  — equities via Yahoo Finance proxy (no API key required)
+ * crypto-price  — cryptocurrencies via CoinGecko proxy (no API key required)
+ */
+(function (WIDGETS) {
+  'use strict';
+
+  function renderIcon(name) {
+    if (typeof window !== 'undefined' && window.renderIcon) return window.renderIcon(name);
+    return '';
+  }
+
+  function row(left, price, change, up) {
+    var color = up ? '#3fb950' : '#f85149';
+    return '<div style="display:flex;justify-content:space-between;align-items:center;padding:5px 0;border-bottom:1px solid #21262d;">'
+      + '<span style="font-weight:600;font-size:13px;">' + _esc(left) + '</span>'
+      + '<span style="text-align:right;">'
+      + '<span style="font-size:13px;font-weight:700;margin-right:8px;">' + _esc(price) + '</span>'
+      + '<span style="font-size:11px;color:' + color + ';font-weight:600;">' + _esc(change) + '%</span>'
+      + '</span></div>';
+  }
+
+  // ── Stock Ticker ──────────────────────────────────────────────────────────
+
+  WIDGETS['stock-ticker'] = {
+    name: 'Stock Ticker',
+    icon: '📈',
+    category: 'large',
+    description: 'Live stock prices via Yahoo Finance. No API key required.',
+    defaultWidth: 320,
+    defaultHeight: 280,
+    hasApiKey: false,
+    properties: {
+      title: 'Stocks',
+      symbols: 'AAPL,MSFT,GOOGL,AMZN',
+      refreshInterval: 300
+    },
+    preview: '<div style="padding:6px;font-size:11px;">'
+      + '<div style="display:flex;justify-content:space-between;"><span>AAPL</span><span>$182.50 <span style="color:#3fb950;">+1.24%</span></span></div>'
+      + '<div style="display:flex;justify-content:space-between;"><span>MSFT</span><span>$375.20 <span style="color:#f85149;">-0.38%</span></span></div>'
+      + '</div>',
+    generateHtml: function (props) {
+      return '<div class="dash-card" id="widget-' + props.id + '" style="height:100%;">'
+        + '<div class="dash-card-head">'
+        + '<span class="dash-card-title">' + renderIcon('stock') + ' ' + _esc(props.title || 'Stocks') + '</span>'
+        + '<span class="dash-card-badge" id="' + props.id + '-badge">—</span>'
+        + '</div>'
+        + '<div class="dash-card-body" id="' + props.id + '-list" style="overflow-y:auto;padding:4px 8px;">'
+        + '<div style="color:#8b949e;font-size:12px;">Loading...</div>'
+        + '</div></div>';
+    },
+    generateJs: function (props) {
+      var fn = 'update_' + props.id.replace(/-/g, '_');
+      return 'async function ' + fn + '() {'
+        + '  var list = document.getElementById("' + props.id + '-list");'
+        + '  var badge = document.getElementById("' + props.id + '-badge");'
+        + '  if (!list) return;'
+        + '  try {'
+        + '    var res = await fetch("/api/finance/stocks?symbols=" + encodeURIComponent("' + (props.symbols || 'AAPL,MSFT') + '"));'
+        + '    if (!res.ok) throw new Error("HTTP " + res.status);'
+        + '    var data = await res.json();'
+        + '    var ok = data.filter(function(d) { return !d.error; });'
+        + '    list.innerHTML = data.map(function(d) {'
+        + '      if (d.error) return \'<div style="padding:5px 0;border-bottom:1px solid #21262d;color:#8b949e;font-size:12px;">\' + _esc(d.symbol) + \' — \' + _esc(d.error) + \'</div>\';'
+        + '      var color = d.up ? "#3fb950" : "#f85149";'
+        + '      return \'<div style="display:flex;justify-content:space-between;align-items:center;padding:5px 0;border-bottom:1px solid #21262d;">\''
+        + '        + \'<span style="font-weight:600;font-size:13px;">\' + _esc(d.symbol) + \'</span>\''
+        + '        + \'<span style="text-align:right;">\''
+        + '        + \'<span style="font-size:13px;font-weight:700;margin-right:8px;">$\' + _esc(d.price) + \'</span>\''
+        + '        + \'<span style="font-size:11px;color:\' + color + \';font-weight:600;">\' + _esc(d.pctChange) + \'%</span>\''
+        + '        + \'</span></div>\';'
+        + '    }).join("");'
+        + '    if (badge) badge.textContent = ok.length + " stocks";'
+        + '  } catch (e) {'
+        + '    console.error("Stock ticker error:", e);'
+        + '    if (list) list.innerHTML = \'<div style="color:#f85149;font-size:12px;">Failed to load</div>\';'
+        + '  }'
+        + '}'
+        + fn + '();'
+        + 'setInterval(' + fn + ', ' + ((props.refreshInterval || 300) * 1000) + ');';
+    }
+  };
+
+  // ── Crypto Price ──────────────────────────────────────────────────────────
+
+  WIDGETS['crypto-price'] = {
+    name: 'Crypto Price',
+    icon: '₿',
+    category: 'large',
+    description: 'Live crypto prices via CoinGecko. No API key required.',
+    defaultWidth: 320,
+    defaultHeight: 280,
+    hasApiKey: false,
+    properties: {
+      title: 'Crypto',
+      coins: 'bitcoin,ethereum,solana',
+      currency: 'usd',
+      refreshInterval: 300
+    },
+    preview: '<div style="padding:6px;font-size:11px;">'
+      + '<div style="display:flex;justify-content:space-between;"><span>Bitcoin</span><span>$67,240 <span style="color:#3fb950;">+2.1%</span></span></div>'
+      + '<div style="display:flex;justify-content:space-between;"><span>Ethereum</span><span>$3,521 <span style="color:#f85149;">-0.8%</span></span></div>'
+      + '</div>',
+    generateHtml: function (props) {
+      return '<div class="dash-card" id="widget-' + props.id + '" style="height:100%;">'
+        + '<div class="dash-card-head">'
+        + '<span class="dash-card-title">' + renderIcon('crypto') + ' ' + _esc(props.title || 'Crypto') + '</span>'
+        + '<span class="dash-card-badge" id="' + props.id + '-badge">—</span>'
+        + '</div>'
+        + '<div class="dash-card-body" id="' + props.id + '-list" style="overflow-y:auto;padding:4px 8px;">'
+        + '<div style="color:#8b949e;font-size:12px;">Loading...</div>'
+        + '</div></div>';
+    },
+    generateJs: function (props) {
+      var fn = 'update_' + props.id.replace(/-/g, '_');
+      var currency = (props.currency || 'usd').toUpperCase();
+      return 'async function ' + fn + '() {'
+        + '  var list = document.getElementById("' + props.id + '-list");'
+        + '  var badge = document.getElementById("' + props.id + '-badge");'
+        + '  if (!list) return;'
+        + '  try {'
+        + '    var res = await fetch("/api/finance/crypto?coins=" + encodeURIComponent("' + (props.coins || 'bitcoin,ethereum') + '") + "&currency=' + (props.currency || 'usd') + '");'
+        + '    if (!res.ok) throw new Error("HTTP " + res.status);'
+        + '    var data = await res.json();'
+        + '    list.innerHTML = data.map(function(d) {'
+        + '      var color = d.up ? "#3fb950" : "#f85149";'
+        + '      return \'<div style="display:flex;justify-content:space-between;align-items:center;padding:5px 0;border-bottom:1px solid #21262d;">\''
+        + '        + \'<span style="font-weight:600;font-size:13px;">\' + _esc(d.name) + \'</span>\''
+        + '        + \'<span style="text-align:right;">\''
+        + '        + \'<span style="font-size:13px;font-weight:700;margin-right:8px;">' + currency + ' \' + _esc(d.price) + \'</span>\''
+        + '        + \'<span style="font-size:11px;color:\' + color + \';font-weight:600;">\' + _esc(d.pctChange) + \'%</span>\''
+        + '        + \'</span></div>\';'
+        + '    }).join("");'
+        + '    if (badge) badge.textContent = data.length + " coins";'
+        + '  } catch (e) {'
+        + '    console.error("Crypto price error:", e);'
+        + '    if (list) list.innerHTML = \'<div style="color:#f85149;font-size:12px;">Failed to load</div>\';'
+        + '  }'
+        + '}'
+        + fn + '();'
+        + 'setInterval(' + fn + ', ' + ((props.refreshInterval || 300) * 1000) + ');';
+    }
+  };
+
+})(typeof window !== 'undefined' ? (window.WIDGETS = window.WIDGETS || {}) : (typeof WIDGETS !== 'undefined' ? WIDGETS : {}));

--- a/js/widgets/search.js
+++ b/js/widgets/search.js
@@ -1,0 +1,119 @@
+/**
+ * LobsterBoard Search Widget
+ * search — search box with DuckDuckGo-style !bangs (pure frontend, no API key)
+ */
+(function (WIDGETS) {
+  'use strict';
+
+  function renderIcon(name) {
+    if (typeof window !== 'undefined' && window.renderIcon) return window.renderIcon(name);
+    return '';
+  }
+
+  var BUILT_IN_BANGS = {
+    'g':    'https://www.google.com/search?q={q}',
+    'b':    'https://www.bing.com/search?q={q}',
+    'yt':   'https://www.youtube.com/results?search_query={q}',
+    'gh':   'https://github.com/search?q={q}',
+    'r':    'https://www.reddit.com/search/?q={q}',
+    'so':   'https://stackoverflow.com/search?q={q}',
+    'w':    'https://en.wikipedia.org/wiki/Special:Search/{q}',
+    'img':  'https://www.google.com/search?tbm=isch&q={q}',
+    'maps': 'https://www.google.com/maps/search/{q}',
+    'ddg':  'https://duckduckgo.com/?q={q}',
+    'npm':  'https://www.npmjs.com/search?q={q}',
+    'mdn':  'https://developer.mozilla.org/en-US/search?q={q}',
+    'x':    'https://x.com/search?q={q}',
+    'tw':   'https://x.com/search?q={q}'
+  };
+
+  var PROVIDERS = {
+    duckduckgo: 'https://duckduckgo.com/?q={q}',
+    google:     'https://www.google.com/search?q={q}',
+    bing:       'https://www.bing.com/search?q={q}',
+    brave:      'https://search.brave.com/search?q={q}'
+  };
+
+  WIDGETS['search'] = {
+    name: 'Search',
+    icon: '🔍',
+    category: 'large',
+    description: 'Search box with DuckDuckGo-style !bangs. Press S to focus, ↑ for last query.',
+    defaultWidth: 460,
+    defaultHeight: 120,
+    hasApiKey: false,
+    properties: {
+      title: 'Search',
+      placeholder: 'Search or use !bangs',
+      searchEngine: 'duckduckgo',
+      openInNewTab: true,
+      showBangHints: true
+    },
+    preview: '<div style="padding:10px;">'
+      + '<input style="width:100%;padding:6px 10px;background:#21262d;border:1px solid #30363d;border-radius:6px;color:#e6edf3;font-size:13px;" placeholder="Search or use !bangs" readonly />'
+      + '<div style="font-size:10px;color:#8b949e;margin-top:6px;">!yt YouTube &nbsp; !gh GitHub &nbsp; !r Reddit &nbsp; !so Stack Overflow</div>'
+      + '</div>',
+    generateHtml: function (props) {
+      var hints = props.showBangHints !== false
+        ? '<div id="' + props.id + '-hints" style="font-size:10px;color:#8b949e;margin-top:5px;line-height:1.6;">'
+          + '<span style="opacity:.7;">!g Google &nbsp; !yt YouTube &nbsp; !gh GitHub &nbsp; !r Reddit &nbsp; !so Stack Overflow &nbsp; !w Wikipedia &nbsp; !npm npm</span>'
+          + '</div>'
+        : '';
+      return '<div class="dash-card" id="widget-' + props.id + '" style="height:100%;">'
+        + '<div class="dash-card-head">'
+        + '<span class="dash-card-title">' + renderIcon('search') + ' ' + _esc(props.title || 'Search') + '</span>'
+        + '</div>'
+        + '<div class="dash-card-body" style="padding:8px 10px;">'
+        + '<form id="' + props.id + '-form" style="display:flex;gap:6px;" onsubmit="return false;">'
+        + '<input id="' + props.id + '-input" type="text"'
+        + '  placeholder="' + _esc(props.placeholder || 'Search or use !bangs') + '"'
+        + '  autocomplete="off" spellcheck="false"'
+        + '  style="flex:1;padding:7px 11px;background:#21262d;border:1px solid #30363d;border-radius:6px;color:#e6edf3;font-size:13px;outline:none;" />'
+        + '<button id="' + props.id + '-btn" type="submit"'
+        + '  style="padding:7px 14px;background:#238636;border:none;border-radius:6px;color:#fff;font-size:13px;cursor:pointer;">Go</button>'
+        + '</form>'
+        + hints
+        + '</div></div>';
+    },
+    generateJs: function (props) {
+      var fn = 'initSearch_' + props.id.replace(/-/g, '_');
+      var provider = PROVIDERS[props.searchEngine] || PROVIDERS.duckduckgo;
+      var newTab = props.openInNewTab !== false;
+      return '(function() {'
+        + '  var BANGS = ' + JSON.stringify(BUILT_IN_BANGS) + ';'
+        + '  var DEFAULT_URL = "' + provider + '";'
+        + '  var lastQuery = "";'
+        + '  function navigate(q) {'
+        + '    q = q.trim();'
+        + '    if (!q) return;'
+        + '    lastQuery = q;'
+        + '    var url = DEFAULT_URL;'
+        + '    var m = q.match(/^!(\\S+)\\s*(.*)/);'
+        + '    if (m) {'
+        + '      var bang = m[1].toLowerCase(), rest = m[2];'
+        + '      if (BANGS[bang]) { url = BANGS[bang]; q = rest || q; }'
+        + '    }'
+        + '    var target = url.replace("{q}", encodeURIComponent(q));'
+        + '    if (' + newTab + ') { window.open(target, "_blank", "noopener"); }'
+        + '    else { window.location.href = target; }'
+        + '  }'
+        + '  var form = document.getElementById("' + props.id + '-form");'
+        + '  var input = document.getElementById("' + props.id + '-input");'
+        + '  if (form) form.addEventListener("submit", function() { navigate(input.value); });'
+        + '  if (input) {'
+        + '    input.addEventListener("keydown", function(e) {'
+        + '      if (e.key === "ArrowUp") { e.preventDefault(); input.value = lastQuery; }'
+        + '    });'
+        + '  }'
+        + '  document.addEventListener("keydown", function(e) {'
+        + '    var tag = document.activeElement && document.activeElement.tagName;'
+        + '    if (e.key === "s" && tag !== "INPUT" && tag !== "TEXTAREA" && !e.ctrlKey && !e.metaKey) {'
+        + '      var inp = document.getElementById("' + props.id + '-input");'
+        + '      if (inp) { inp.focus(); inp.select(); e.preventDefault(); }'
+        + '    }'
+        + '  });'
+        + '})();';
+    }
+  };
+
+})(typeof window !== 'undefined' ? (window.WIDGETS = window.WIDGETS || {}) : (typeof WIDGETS !== 'undefined' ? WIDGETS : {}));

--- a/server.cjs
+++ b/server.cjs
@@ -36,6 +36,7 @@ const dataRoutes = require('./server/routes/data.cjs')();
 const aiUsageRoutes = require('./server/routes/ai-usage.cjs')();
 const systemRoutes = require('./server/routes/system.cjs')(ctx);
 const proxyRoutes = require('./server/routes/proxy.cjs')();
+const financeRoutes = require('./server/routes/finance.cjs')();
 const templateRoutes = require('./server/routes/templates.cjs')(ctx);
 const fileRoutes = require('./server/routes/files.cjs')(ctx);
 
@@ -171,6 +172,9 @@ const server = http.createServer(async (req, res) => {
 
   // Proxy routes (RSS, calendar, quote)
   if (proxyRoutes.handle(req, res, pathname, parsedUrl)) return;
+
+  // Finance routes (stocks via Yahoo Finance, crypto via CoinGecko)
+  if (financeRoutes.handle(req, res, pathname, parsedUrl)) return;
 
   // Stats routes
   if (req.method === 'GET' && pathname === '/api/stats') {

--- a/server/routes/finance.cjs
+++ b/server/routes/finance.cjs
@@ -1,0 +1,92 @@
+const https = require('https');
+const { sendJson, sendError } = require('../response.cjs');
+
+function fetchJson(url) {
+  return new Promise((resolve, reject) => {
+    const req = https.get(url, {
+      headers: { 'User-Agent': 'LobsterBoard/1.0' },
+      timeout: 10000
+    }, (proxyRes) => {
+      let body = '';
+      proxyRes.on('data', c => { body += c; if (body.length > 1000000) proxyRes.destroy(); });
+      proxyRes.on('end', () => {
+        try { resolve(JSON.parse(body)); }
+        catch (e) { reject(new Error('Invalid JSON from upstream')); }
+      });
+    });
+    req.on('error', reject);
+    req.on('timeout', () => { req.destroy(); reject(new Error('Request timed out')); });
+  });
+}
+
+async function handleStocks(symbols) {
+  return Promise.all(symbols.map(async (symbol) => {
+    try {
+      const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(symbol)}?interval=1d&range=1d`;
+      const data = await fetchJson(url);
+      const meta = data?.chart?.result?.[0]?.meta;
+      if (!meta) return { symbol, error: 'Not found' };
+      const price = meta.regularMarketPrice || 0;
+      const prev = meta.previousClose || meta.chartPreviousClose || price;
+      const change = price - prev;
+      const pctChange = prev ? (change / prev) * 100 : 0;
+      return {
+        symbol,
+        price: price.toFixed(2),
+        change: change >= 0 ? '+' + change.toFixed(2) : change.toFixed(2),
+        pctChange: pctChange >= 0 ? '+' + pctChange.toFixed(2) : pctChange.toFixed(2),
+        up: change >= 0,
+        currency: meta.currency || 'USD'
+      };
+    } catch (e) {
+      return { symbol, error: e.message };
+    }
+  }));
+}
+
+async function handleCrypto(coins, currency) {
+  const url = `https://api.coingecko.com/api/v3/simple/price?ids=${encodeURIComponent(coins)}&vs_currencies=${encodeURIComponent(currency)}&include_24hr_change=true`;
+  const data = await fetchJson(url);
+  return Object.entries(data).map(([id, vals]) => {
+    const price = vals[currency] || 0;
+    const pctRaw = vals[`${currency}_24h_change`] || 0;
+    return {
+      id,
+      name: id.charAt(0).toUpperCase() + id.slice(1).replace(/-/g, ' '),
+      price: price >= 1 ? price.toLocaleString('en-US', { maximumFractionDigits: 2 }) : price.toFixed(6),
+      pctChange: pctRaw >= 0 ? '+' + pctRaw.toFixed(2) : pctRaw.toFixed(2),
+      up: pctRaw >= 0,
+      currency: currency.toUpperCase()
+    };
+  });
+}
+
+function handle(req, res, pathname, parsedUrl) {
+  if (req.method === 'GET' && pathname === '/api/finance/stocks') {
+    const raw = parsedUrl.searchParams.get('symbols') || '';
+    const symbols = raw.toUpperCase().split(',').map(s => s.trim()).filter(s => /^[A-Z0-9.\-^]{1,10}$/.test(s)).slice(0, 20);
+    if (!symbols.length) { sendError(res, 'Missing or invalid symbols parameter', 400); return true; }
+    handleStocks(symbols)
+      .then(results => sendJson(res, 200, results))
+      .catch(e => sendError(res, e.message));
+    return true;
+  }
+
+  if (req.method === 'GET' && pathname === '/api/finance/crypto') {
+    const raw = parsedUrl.searchParams.get('coins') || 'bitcoin,ethereum';
+    const coins = raw.toLowerCase().split(',').map(s => s.trim()).filter(s => /^[a-z0-9\-]{1,50}$/.test(s)).slice(0, 20).join(',');
+    const currency = /^[a-z]{2,5}$/.test(parsedUrl.searchParams.get('currency') || 'usd')
+      ? parsedUrl.searchParams.get('currency').toLowerCase() : 'usd';
+    if (!coins) { sendError(res, 'Missing or invalid coins parameter', 400); return true; }
+    handleCrypto(coins, currency)
+      .then(results => sendJson(res, 200, results))
+      .catch(e => sendError(res, e.message));
+    return true;
+  }
+
+  return false;
+}
+
+module.exports = function () {
+  return { handle };
+};

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -613,6 +613,194 @@ export const WIDGETS = {
       async function update_${props.id.replace(/-/g,'_')}() { const body = document.getElementById('${props.id}-body'); const subEl = document.getElementById('${props.id}-sub'); try { const res = await fetch('/api/pages/claude-usage/usage'); const d = await res.json(); if (d.error) { body.innerHTML='<div style="color:#f85149;">'+d.error+'</div>'; return; } if (subEl) { subEl.textContent = {max:'Max (5×)',pro:'Pro',free:'Free'}[d.subscription]||d.subscription||''; } let html=''; if(d.five_hour) html+=usageBar('5h Session',d.five_hour.utilization,d.five_hour.resets_at); if(d.seven_day) html+=usageBar('7d Weekly',d.seven_day.utilization,d.seven_day.resets_at); if(d.seven_day_opus) html+=usageBar('Opus (7d)',d.seven_day_opus.utilization,d.seven_day_opus.resets_at); if(d.seven_day_sonnet&&d.seven_day_sonnet.utilization>0) html+=usageBar('Sonnet (7d)',d.seven_day_sonnet.utilization,d.seven_day_sonnet.resets_at); if(d.extra_usage&&d.extra_usage.is_enabled){const used=(d.extra_usage.used_credits/100).toFixed(2),limit=d.extra_usage.monthly_limit>0?(d.extra_usage.monthly_limit/100).toFixed(2):'∞';html+='<div style="margin-top:4px;padding-top:6px;border-top:1px solid #30363d;"><div style="display:flex;justify-content:space-between;font-size:11px;"><span style="color:#8b949e;">Extra Usage</span><span style="font-weight:600;">$'+used+' / $'+limit+'</span></div></div>';} if(!html) html='<div style="color:#8b949e;">No usage data</div>'; body.innerHTML=html; } catch(e) { console.error('Claude usage error:',e); body.innerHTML='<div style="color:#f85149;">Failed to load</div>'; } }
       update_${props.id.replace(/-/g,'_')}(); setInterval(update_${props.id.replace(/-/g,'_')}, ${(props.refreshInterval||120)*1000});
     `
+  },
+
+  // ── Finance ──────────────────────────────────────────────────────────────
+
+  'stock-ticker': {
+    name: 'Stock Ticker',
+    icon: '📈',
+    category: 'large',
+    description: 'Live stock prices via Yahoo Finance. No API key required.',
+    defaultWidth: 320,
+    defaultHeight: 280,
+    hasApiKey: false,
+    properties: {
+      title: 'Stocks',
+      symbols: 'AAPL,MSFT,GOOGL,AMZN',
+      refreshInterval: 300
+    },
+    preview: `<div style="padding:6px;font-size:11px;">
+      <div style="display:flex;justify-content:space-between;"><span>AAPL</span><span>$182.50 <span style="color:#3fb950;">+1.24%</span></span></div>
+      <div style="display:flex;justify-content:space-between;"><span>MSFT</span><span>$375.20 <span style="color:#f85149;">-0.38%</span></span></div>
+    </div>`,
+    generateHtml: (props) => `
+      <div class="dash-card" id="widget-${props.id}" style="height:100%;">
+        <div class="dash-card-head">
+          <span class="dash-card-title">📈 ${props.title || 'Stocks'}</span>
+          <span class="dash-card-badge" id="${props.id}-badge">—</span>
+        </div>
+        <div class="dash-card-body" id="${props.id}-list" style="overflow-y:auto;padding:4px 8px;">
+          <div style="color:#8b949e;font-size:12px;">Loading...</div>
+        </div>
+      </div>`,
+    generateJs: (props) => `
+      async function update_${props.id.replace(/-/g, '_')}() {
+        var list = document.getElementById('${props.id}-list');
+        var badge = document.getElementById('${props.id}-badge');
+        if (!list) return;
+        try {
+          var res = await fetch('/api/finance/stocks?symbols=' + encodeURIComponent('${props.symbols || 'AAPL,MSFT'}'));
+          if (!res.ok) throw new Error('HTTP ' + res.status);
+          var data = await res.json();
+          var ok = data.filter(function(d) { return !d.error; });
+          list.innerHTML = data.map(function(d) {
+            if (d.error) return '<div style="padding:5px 0;border-bottom:1px solid #21262d;color:#8b949e;font-size:12px;">' + _esc(d.symbol) + ' — ' + _esc(d.error) + '</div>';
+            var color = d.up ? '#3fb950' : '#f85149';
+            return '<div style="display:flex;justify-content:space-between;align-items:center;padding:5px 0;border-bottom:1px solid #21262d;">'
+              + '<span style="font-weight:600;font-size:13px;">' + _esc(d.symbol) + '</span>'
+              + '<span style="text-align:right;">'
+              + '<span style="font-size:13px;font-weight:700;margin-right:8px;">$' + _esc(d.price) + '</span>'
+              + '<span style="font-size:11px;color:' + color + ';font-weight:600;">' + _esc(d.pctChange) + '%</span>'
+              + '</span></div>';
+          }).join('');
+          if (badge) badge.textContent = ok.length + ' stocks';
+        } catch (e) {
+          console.error('Stock ticker error:', e);
+          if (list) list.innerHTML = '<div style="color:#f85149;font-size:12px;">Failed to load</div>';
+        }
+      }
+      update_${props.id.replace(/-/g, '_')}();
+      setInterval(update_${props.id.replace(/-/g, '_')}, ${(props.refreshInterval || 300) * 1000});
+    `
+  },
+
+  'crypto-price': {
+    name: 'Crypto Price',
+    icon: '₿',
+    category: 'large',
+    description: 'Live crypto prices via CoinGecko. No API key required.',
+    defaultWidth: 320,
+    defaultHeight: 280,
+    hasApiKey: false,
+    properties: {
+      title: 'Crypto',
+      coins: 'bitcoin,ethereum,solana',
+      currency: 'usd',
+      refreshInterval: 300
+    },
+    preview: `<div style="padding:6px;font-size:11px;">
+      <div style="display:flex;justify-content:space-between;"><span>Bitcoin</span><span>$67,240 <span style="color:#3fb950;">+2.1%</span></span></div>
+      <div style="display:flex;justify-content:space-between;"><span>Ethereum</span><span>$3,521 <span style="color:#f85149;">-0.8%</span></span></div>
+    </div>`,
+    generateHtml: (props) => `
+      <div class="dash-card" id="widget-${props.id}" style="height:100%;">
+        <div class="dash-card-head">
+          <span class="dash-card-title">₿ ${props.title || 'Crypto'}</span>
+          <span class="dash-card-badge" id="${props.id}-badge">—</span>
+        </div>
+        <div class="dash-card-body" id="${props.id}-list" style="overflow-y:auto;padding:4px 8px;">
+          <div style="color:#8b949e;font-size:12px;">Loading...</div>
+        </div>
+      </div>`,
+    generateJs: (props) => `
+      async function update_${props.id.replace(/-/g, '_')}() {
+        var list = document.getElementById('${props.id}-list');
+        var badge = document.getElementById('${props.id}-badge');
+        if (!list) return;
+        try {
+          var res = await fetch('/api/finance/crypto?coins=' + encodeURIComponent('${props.coins || 'bitcoin,ethereum'}') + '&currency=${props.currency || 'usd'}');
+          if (!res.ok) throw new Error('HTTP ' + res.status);
+          var data = await res.json();
+          list.innerHTML = data.map(function(d) {
+            var color = d.up ? '#3fb950' : '#f85149';
+            return '<div style="display:flex;justify-content:space-between;align-items:center;padding:5px 0;border-bottom:1px solid #21262d;">'
+              + '<span style="font-weight:600;font-size:13px;">' + _esc(d.name) + '</span>'
+              + '<span style="text-align:right;">'
+              + '<span style="font-size:13px;font-weight:700;margin-right:8px;">${(props.currency || 'usd').toUpperCase()} ' + _esc(d.price) + '</span>'
+              + '<span style="font-size:11px;color:' + color + ';font-weight:600;">' + _esc(d.pctChange) + '%</span>'
+              + '</span></div>';
+          }).join('');
+          if (badge) badge.textContent = data.length + ' coins';
+        } catch (e) {
+          console.error('Crypto price error:', e);
+          if (list) list.innerHTML = '<div style="color:#f85149;font-size:12px;">Failed to load</div>';
+        }
+      }
+      update_${props.id.replace(/-/g, '_')}();
+      setInterval(update_${props.id.replace(/-/g, '_')}, ${(props.refreshInterval || 300) * 1000});
+    `
+  },
+
+  // ── Search ────────────────────────────────────────────────────────────────
+
+  'search': {
+    name: 'Search',
+    icon: '🔍',
+    category: 'large',
+    description: 'Search box with DuckDuckGo-style !bangs. Press S to focus, ↑ for last query.',
+    defaultWidth: 460,
+    defaultHeight: 120,
+    hasApiKey: false,
+    properties: {
+      title: 'Search',
+      placeholder: 'Search or use !bangs',
+      searchEngine: 'duckduckgo',
+      openInNewTab: true,
+      showBangHints: true
+    },
+    preview: `<div style="padding:10px;">
+      <input style="width:100%;padding:6px 10px;background:#21262d;border:1px solid #30363d;border-radius:6px;color:#e6edf3;font-size:13px;" placeholder="Search or use !bangs" readonly />
+      <div style="font-size:10px;color:#8b949e;margin-top:6px;">!yt YouTube &nbsp; !gh GitHub &nbsp; !r Reddit &nbsp; !so Stack Overflow</div>
+    </div>`,
+    generateHtml: (props) => `
+      <div class="dash-card" id="widget-${props.id}" style="height:100%;">
+        <div class="dash-card-head">
+          <span class="dash-card-title">🔍 ${props.title || 'Search'}</span>
+        </div>
+        <div class="dash-card-body" style="padding:8px 10px;">
+          <form id="${props.id}-form" style="display:flex;gap:6px;" onsubmit="return false;">
+            <input id="${props.id}-input" type="text"
+              placeholder="${props.placeholder || 'Search or use !bangs'}"
+              autocomplete="off" spellcheck="false"
+              style="flex:1;padding:7px 11px;background:#21262d;border:1px solid #30363d;border-radius:6px;color:#e6edf3;font-size:13px;outline:none;" />
+            <button type="submit"
+              style="padding:7px 14px;background:#238636;border:none;border-radius:6px;color:#fff;font-size:13px;cursor:pointer;">Go</button>
+          </form>
+          ${props.showBangHints !== false ? `<div style="font-size:10px;color:#8b949e;margin-top:5px;"><span style="opacity:.7;">!g Google &nbsp; !yt YouTube &nbsp; !gh GitHub &nbsp; !r Reddit &nbsp; !so Stack Overflow &nbsp; !w Wikipedia &nbsp; !npm npm</span></div>` : ''}
+        </div>
+      </div>`,
+    generateJs: (props) => {
+      const providers = { duckduckgo:'https://duckduckgo.com/?q={q}', google:'https://www.google.com/search?q={q}', bing:'https://www.bing.com/search?q={q}', brave:'https://search.brave.com/search?q={q}' };
+      const bangs = { g:'https://www.google.com/search?q={q}',b:'https://www.bing.com/search?q={q}',yt:'https://www.youtube.com/results?search_query={q}',gh:'https://github.com/search?q={q}',r:'https://www.reddit.com/search/?q={q}',so:'https://stackoverflow.com/search?q={q}',w:'https://en.wikipedia.org/wiki/Special:Search/{q}',img:'https://www.google.com/search?tbm=isch&q={q}',maps:'https://www.google.com/maps/search/{q}',ddg:'https://duckduckgo.com/?q={q}',npm:'https://www.npmjs.com/search?q={q}',mdn:'https://developer.mozilla.org/en-US/search?q={q}',x:'https://x.com/search?q={q}',tw:'https://x.com/search?q={q}' };
+      const defaultUrl = providers[props.searchEngine] || providers.duckduckgo;
+      return `
+        (function() {
+          var BANGS = ${JSON.stringify(bangs)};
+          var DEFAULT_URL = '${defaultUrl}';
+          var lastQuery = '';
+          function navigate(q) {
+            q = q.trim(); if (!q) return; lastQuery = q;
+            var url = DEFAULT_URL;
+            var m = q.match(/^!(\\S+)\\s*(.*)/);
+            if (m) { var bang = m[1].toLowerCase(), rest = m[2]; if (BANGS[bang]) { url = BANGS[bang]; q = rest || q; } }
+            var target = url.replace('{q}', encodeURIComponent(q));
+            if (${props.openInNewTab !== false}) { window.open(target, '_blank', 'noopener'); } else { window.location.href = target; }
+          }
+          var form = document.getElementById('${props.id}-form');
+          var input = document.getElementById('${props.id}-input');
+          if (form) form.addEventListener('submit', function() { navigate(input.value); });
+          if (input) input.addEventListener('keydown', function(e) { if (e.key === 'ArrowUp') { e.preventDefault(); input.value = lastQuery; } });
+          document.addEventListener('keydown', function(e) {
+            var tag = document.activeElement && document.activeElement.tagName;
+            if (e.key === 's' && tag !== 'INPUT' && tag !== 'TEXTAREA' && !e.ctrlKey && !e.metaKey) {
+              var inp = document.getElementById('${props.id}-input');
+              if (inp) { inp.focus(); inp.select(); e.preventDefault(); }
+            }
+          });
+        })();
+      `;
+    }
   }
 };
 


### PR DESCRIPTION
## Summary
- **Stock Ticker** — live equity prices from Yahoo Finance via server proxy. No API key required. Default symbols: AAPL, MSFT, GOOGL, AMZN. Configurable refresh interval.
- **Crypto Price** — live crypto prices from CoinGecko via server proxy. No API key required. Default coins: bitcoin, ethereum, solana. Configurable currency and refresh.
- **Search with Bangs** — search box with 14 built-in `!bangs` (`!yt`, `!gh`, `!r`, `!so`, `!w`, `!npm`, `!mdn`, `!maps`, `!img`, `!g`, `!b`, `!ddg`, `!x`, `!tw`). Press `S` anywhere to focus. `↑` recalls last query. Choice of DuckDuckGo / Google / Bing / Brave as default engine.

## What changed
| File | Change |
|---|---|
| `server/routes/finance.cjs` | New proxy: `/api/finance/stocks` (Yahoo Finance) and `/api/finance/crypto` (CoinGecko) |
| `server.cjs` | Registers `financeRoutes` |
| `js/widgets/finance.js` | Browser IIFE for stock-ticker + crypto-price |
| `js/widgets/search.js` | Browser IIFE for search widget |
| `app.html` | Script tags for the two new widget files |
| `js/widgets.js` | Monolith updated (required by tests) |
| `src/widgets.js` | ESM source updated |

## Test plan
- [ ] `npm test` — all 54 tests pass
- [ ] Add a Stock Ticker widget → see AAPL, MSFT, GOOGL, AMZN with live prices and green/red % change
- [ ] Add a Crypto Price widget → see Bitcoin, Ethereum, Solana prices
- [ ] Add a Search widget → type `!yt cats` → opens YouTube search in new tab
- [ ] Press `S` on dashboard → search input focuses
- [ ] Press `↑` in search input → last query recalled

🤖 Generated with [Claude Code](https://claude.com/claude-code)